### PR TITLE
Fix to "ERROR! 'version' is not a valid attribute for a RoleMetadata"

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,4 +32,3 @@ galaxy_info:
   - development
 
 dependencies: []
-version: 0.1.0


### PR DESCRIPTION
    ERROR! 'version' is not a valid attribute for a RoleMetadata
    
    The error appears to have been in '/usr/local/etc/ansible/roles/altermn.rvm/meta/main.yml': line 2, column 1, but may
    be elsewhere in the file depending on the exact syntax problem.
    
    The offending line appears to be:
    
    ---
    galaxy_info:
    ^ here